### PR TITLE
Additional changes to the backend

### DIFF
--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -180,6 +180,7 @@ post '/cloudcmd' do
   cmd = FlightFileManager.config
                          .cloudcmd_command
                          .gsub('$config_path', config_path)
+                         .gsub('$port_path', port_path)
   FlightFileManager.logger.info("Executing Command: #{cmd}")
 
   # Create the log directory
@@ -192,9 +193,8 @@ post '/cloudcmd' do
     # What should happen to the child processes when the server exists?
     # XXX: Remove the config file path on exit
 
-    # Open the required file descriptors before changing user
+    # Open the logging file descriptor before switching user permissions
     log_io = File.open(log_path, 'a')
-    port_io = File.open(port_path, 'w')
 
     # Become the session leader as the correct user
     Process::Sys.setgid(passwd.gid)
@@ -207,8 +207,7 @@ post '/cloudcmd' do
                 unsetenv_others: true,
                 close_others: true,
                 chdir: passwd.dir,
-                [:out, :err] => log_io,
-                3 => port_io)
+                [:out, :err] => log_io)
   end
   FileUtils.mkdir_p File.dirname(pid_path)
   File.write pid_path, pid

--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -47,7 +47,7 @@ error(HttpError) do
   LOGGER.send level, e.full_message
   status e.http_status
   if e.http_status == 401
-    response["WWW-Authenticate"] = 'Basic realm="Cloud Commander"'
+    response["WWW-Authenticate"] = 'Basic realm="Flight File Manager"'
   end
   { errors: [e] }.to_json
 end

--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -228,7 +228,7 @@ post '/cloudcmd' do
     sleep 1
     if (now = Process.clock_gettime(Process::CLOCK_MONOTONIC)) > timeout
       timeout = now + FlightFileManager.config.launch_timeout
-      Process.kill('SIGTERM', pid)
+      Process.kill(-Signal.list['TERM'], pid)
     end
   end
 
@@ -255,7 +255,7 @@ delete '/cloudcmd' do
   if pid
     begin
       FlightFileManager.logger.info "Shutting down '#{current_user}' cloudcmd server (PID: #{pid})"
-      Process.kill('SIGTERM', pid)
+      Process.kill(-Signal.list['TERM'], pid)
     rescue Errno::ESRCH
       # NOOP - Don't worry if it has already ended
     end

--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -46,6 +46,9 @@ error(HttpError) do
   level = (e.is_a?(UnexpectedError) ? :error : :debug)
   LOGGER.send level, e.full_message
   status e.http_status
+  if e.http_status == 401
+    response["WWW-Authenticate"] = 'Basic realm="Cloud Commander"'
+  end
   { errors: [e] }.to_json
 end
 

--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -222,7 +222,9 @@ post '/cloudcmd' do
   timeout = Process.clock_gettime(Process::CLOCK_MONOTONIC) + FlightFileManager.config.launch_timeout
   loop do
     break if Process.wait2(pid, Process::WNOHANG)
-    break if File.exists?(port_path)
+    if File.exists?(port_path)
+      break unless File.read(port_path).empty?
+    end
     sleep 1
     if (now = Process.clock_gettime(Process::CLOCK_MONOTONIC)) > timeout
       timeout = now + FlightFileManager.config.launch_timeout

--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -196,10 +196,15 @@ post '/cloudcmd' do
     # Open the logging file descriptor before switching user permissions
     log_io = File.open(log_path, 'a')
 
+    # Ensure the user has an empty port path file to write to
+    FileUtils.rm_f port_path
+    FileUtils.touch port_path
+    FileUtils.chown(current_user, current_user, port_path)
+
     # Become the session leader as the correct user
+    Process.setsid
     Process::Sys.setgid(passwd.gid)
     Process::Sys.setuid(passwd.uid)
-    Process.setsid
 
     # Exec into the cloud command
     Kernel.exec({},

--- a/supervisor/etc/flight-file-manager.yaml
+++ b/supervisor/etc/flight-file-manager.yaml
@@ -35,7 +35,6 @@
 #-------------------------------------------------------------------------------
 # PID File Path
 # The path to where the PID of the supervisor process should be stored
-# The environment variable FLIGHT_FILE_MANAGER_PIDFILE takes precedence
 #
 # The default is relative to the install directory. All overrides should use
 # absolute paths. The behaviour of overrides with relative paths is undefined.
@@ -72,6 +71,15 @@
 # interpreted as a literal string and should not be quoted.
 #-------------------------------------------------------------------------------
 # cloudcmd_command: /path/to/flight-file-manager/libexec/cloudcmd.sh $config_path $port_path
+
+#-------------------------------------------------------------------------------
+# Cloudcmd Launch Timeout
+# Specify how long the cloudcmd process has to write its port. The process will
+# be terminated if it does not return its port within this period.
+#
+# The time is given in seconds
+#-------------------------------------------------------------------------------
+# launch_timeout: 10
 
 #-------------------------------------------------------------------------------
 # Cache Directory

--- a/supervisor/etc/flight-file-manager.yaml
+++ b/supervisor/etc/flight-file-manager.yaml
@@ -55,16 +55,17 @@
 #-------------------------------------------------------------------------------
 # Cloudcmd Command
 # Specify the command that will launch the cloudcmd service. The command
-# support must write the port it started on to file descriptor 3. Failure to
-# write the port will prevent users from connecting to the service. The port
-# must not contain non-integer characters including newline.
-#
-# There is a special '$config_path' variable which should be included in the
-# command. This will be substituted for the pre-generated cloudcmd config path
-# containing the username/password.
+# supports two special variables: $config_path and $port_path.
 #
 # The $config_path is the pre-generated cloudcmd config for the particular
 # user and contains the username/password.
+#
+# The $port_path will be an empty path initially. It is the commands
+# responsibility to select a port that cloudcmd will be started on and write it
+# to this path. Failure to do so will prevent the API consumer from connecting
+# to the service.
+# NOTE: The port_path must only contain the port as an integer. It must not
+#       contain a trailing newline.
 #
 # For security reasons, the command is not executed via a subshell. This means
 # all other string interplation/ variables have been disabled. Each argument is

--- a/supervisor/etc/flight-file-manager.yaml
+++ b/supervisor/etc/flight-file-manager.yaml
@@ -56,17 +56,16 @@
 #-------------------------------------------------------------------------------
 # Cloudcmd Command
 # Specify the command that will launch the cloudcmd service. The command
-# supports two special variables: $config_path and $port_path.
+# support must write the port it started on to file descriptor 3. Failure to
+# write the port will prevent users from connecting to the service. The port
+# must not contain non-integer characters including newline.
+#
+# There is a special '$config_path' variable which should be included in the
+# command. This will be substituted for the pre-generated cloudcmd config path
+# containing the username/password.
 #
 # The $config_path is the pre-generated cloudcmd config for the particular
 # user and contains the username/password.
-#
-# The $port_path will be an empty path initially. It is the commands
-# responsibility to select a port that cloudcmd will be started on and write it
-# to this path. Failure to do so will prevent the API consumer from connecting
-# to the service.
-# NOTE: The port_path must only contain the port as an integer. It must not
-#       contain a trailing newline.
 #
 # For security reasons, the command is not executed via a subshell. This means
 # all other string interplation/ variables have been disabled. Each argument is

--- a/supervisor/etc/flight-file-manager.yaml
+++ b/supervisor/etc/flight-file-manager.yaml
@@ -60,7 +60,7 @@
 # The $config_path is the pre-generated cloudcmd config for the particular
 # user and contains the username/password.
 #
-# The $port_path will be an empty path initially. It is the commands
+# The $port_path will be an empty file initially. It is the commands
 # responsibility to select a port that cloudcmd will be started on and write it
 # to this path. Failure to do so will prevent the API consumer from connecting
 # to the service.

--- a/supervisor/lib/flight_file_manager/configuration.rb
+++ b/supervisor/lib/flight_file_manager/configuration.rb
@@ -39,7 +39,7 @@ module FlightFileManager
     ATTRIBUTES = [
       {
         name: 'port',
-        env_var: true,
+        env_var: false,
         default: 920
       },
       {
@@ -74,6 +74,11 @@ module FlightFileManager
           path = root.join('libexec/cloudcmd.sh')
           "#{path} $config_path $port_path"
         end
+      },
+      {
+        name: 'launch_timeout',
+        env_var: false,
+        default: 10
       }
     ]
     attr_accessor(*ATTRIBUTES.map { |a| a[:name] })


### PR DESCRIPTION
This PR expands on the initial backend work and does the following:

1. Removed YAGNI ~Adds a route `/authorize/:port` which checks if a user has access to a particular port~,
2. Fixes permissions issues around the `log_path`/`port_path` given to `cloudcmd`,
3. Adds a timeout to catch when `cloudcmd` does not write out its port, and
4. Prompt the client for the Basic authentication if required