### PR TITLE
Hardening

### DIFF
--- a/backend/src/main.js
+++ b/backend/src/main.js
@@ -3,6 +3,7 @@ const cloudcmd = require('cloudcmd');
 const validate = require('cloudcmd/server/validate');
 const showConfig = require('cloudcmd/server/show-config');
 const criton = require('criton');
+const fs = require('fs');
 
 const packageInfo = require('../package.json');
 const startServer = require('./server');
@@ -12,7 +13,7 @@ const { argv } = process;
 const args = require('minimist')(argv.slice(2), {
   string: [
     'config',
-    'password',
+    'password-path',
     'port-path',
     'prefix',
   ],
@@ -22,7 +23,6 @@ const args = require('minimist')(argv.slice(2), {
   alias: {
     v: 'version',
     h: 'help',
-    p: 'password',
     c: 'config',
   },
   unknown: (cmd) => {
@@ -48,9 +48,9 @@ function help() {
   const options = {
     "-h, --help                 ": "display this help and exit",
     "-v, --version              ": "display version and exit",
-    "-p, --password             ": "set password",
     "-c, --config               ": "configuration file path",
     "--show-config              ": "show config values",
+    "--password-path            ": "file to read the password from",
     "--port-path                ": "file to write the port to",
   }
   const usage = 'Usage: backend [options]';
@@ -94,7 +94,8 @@ async function main() {
     columns: config('columns'),
   };
 
-  const p = await getPassword(args.password, config);
+  const rawPass = fs.readFileSync(args['password-path'], { encoding:'utf8' });
+  const p = await getPassword(rawPass, config);
   config('password', p);
   await validateRoot(cloudcmdOptions.root, config);
 

--- a/client/src/CurrentUserContext.js
+++ b/client/src/CurrentUserContext.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 
 import useLocalStorage from './useLocalStorage';
+import useCookie from './useCookie';
 
 const initialState = null;
 const Context = React.createContext(initialState);
@@ -12,6 +13,8 @@ function getAuthToken({ username, password }) {
 function Provider({ children }) {
   const [tempUser, doSetTempUser] = useState(null);
   const [currentUser, setCurrentUser] = useLocalStorage('currentUser', initialState);
+  const [_, updateCookie] = useCookie("auth_token", "");
+
   const actions = useMemo(
     () => ({
       setTempUser(username, password) {
@@ -22,12 +25,15 @@ function Provider({ children }) {
       promoteUser(user) {
         setCurrentUser(user);
         doSetTempUser(null);
+        const basicAuthToken = tempUser.authToken;
+        updateCookie(basicAuthToken, 1);
       },
 
       signOut() {
         window.dispatchEvent(new CustomEvent('signout'));
         setCurrentUser(null);
         doSetTempUser(null);
+        updateCookie("");
       },
     }),
     [ setCurrentUser ],

--- a/client/src/useCookie.js
+++ b/client/src/useCookie.js
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+function getItem(key) {
+  return document.cookie.split("; ").reduce((total, currentCookie) => {
+    const item = currentCookie.split("=");
+    const storedKey = item[0];
+    const storedValue = item[1];
+
+    return key === storedKey ? decodeURIComponent(storedValue) : total;
+  }, "");
+}
+
+function setItem(key, value, numberOfDays) {
+  const now = new Date();
+
+  // set the time to be now + numberOfDays
+  now.setTime(now.getTime() + numberOfDays * 60 * 60 * 24 * 1000);
+
+  const secure = document.location.protocol === 'https:';
+
+  document.cookie = `${key}=${value}; expires=${now.toUTCString()}; path=/; samesite=strict; ${secure}`;
+};
+
+/**
+ *
+ * @param {String} key The key to store our data to
+ * @param {String} defaultValue The default value to return in case the cookie doesn't exist
+ */
+function useCookie(key, defaultValue) {
+  const getCookie = () => getItem(key) || defaultValue;
+  const [cookie, setCookie] = useState(getCookie());
+
+  const updateCookie = (value, numberOfDays) => {
+    setCookie(value);
+    setItem(key, value, numberOfDays);
+  };
+
+  return [cookie, updateCookie];
+};
+
+export default useCookie;

--- a/supervisor/app.rb
+++ b/supervisor/app.rb
@@ -158,6 +158,7 @@ end
 post '/cloudcmd' do
   config_path = File.join(FlightFileManager.config.cache_dir, current_user, 'cloudcmd.json')
   port_path = File.join(FlightFileManager.config.cache_dir, current_user, 'cloudcmd.port')
+  password_path = File.join(FlightFileManager.config.cache_dir, current_user, 'cloudcmd.password')
   if running?
     if File.exists?(port_path)
       port = File.read(port_path).chomp
@@ -192,12 +193,15 @@ post '/cloudcmd' do
   FileUtils.mkdir_p File.dirname(config_path)
   File.write(config_path, config.to_json)
   FileUtils.rm_f port_path
+  FileUtils.rm_f password_path
+  File.open(password_path, 'w', 0600) { |f| f.write(password) }
+  FileUtils.chown(current_user, current_user, password_path)
 
   # Generate the command
   cmd = [
     FlightFileManager.config.cloudcmd_command,
     '--config', config_path,
-    '--password', password,
+    '--password-path', password_path,
     '--port-path', port_path,
   ]
   FlightFileManager.logger.info(


### PR DESCRIPTION
1. Use session cookie rather than basic auth for access to cloudcmd.  This prevents the browser from showing an additional authentication dialog box.
2. Don't pass password to cloudcmd on the command line.