### PR TITLE
Open `cloudcmd` at a specified directory

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -15,7 +15,7 @@
 /log
 /vendor
 tags
-etc/flight-file-manager.*.local.yaml
+etc/flight-file-manager-api.*.local.yaml
 usr
 etc/shared-secret.conf
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -77,9 +77,11 @@ class App < Sinatra::Base
                  else
                    File.join(mount_point, 'backend', current_user)
                  end
+      port = request.env['X_REAL_PORT']
+      port = request.port if port.nil? || port == ""
       {
         password: password,
-        url: "//#{request.host}:#{request.port}#{url_path}"
+        url: "//#{request.host}:#{port}#{url_path}"
       }.to_json
     end
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -147,7 +147,7 @@ class App < Sinatra::Base
 
       # Confirm the path is within cloudcmd's root_dir
       rel_path = abs_path.relative_path_from(cloudcmd.root_dir).to_s
-      if /\A..\/.*/.match?(rel_path)
+      if /\A\.\.(\/.*)?\Z/.match?(rel_path)
         status 422
         halt({
           pointer: 'query.dir',

--- a/api/app.rb
+++ b/api/app.rb
@@ -77,7 +77,7 @@ class App < Sinatra::Base
                  else
                    File.join(mount_point, 'backend', current_user)
                  end
-      port = request.env['X_REAL_PORT']
+      port = request.env['HTTP_X_REAL_PORT']
       port = request.port if port.nil? || port == ""
       {
         password: password,

--- a/api/app/cloudcmd.rb
+++ b/api/app/cloudcmd.rb
@@ -99,14 +99,17 @@ class CloudCmd
     end
   end
 
+  def root_dir
+    @root_dir ||= Etc.getpwnam(@user).dir
+  end
+
   private
 
   def cloudcmd_config
-    passwd = Etc.getpwnam(@user)
     mount_point = FlightFileManager.config.mount_point
     {
       prefix: "#{mount_point}/backend/#{@user}",
-      root: passwd.dir,
+      root: root_dir,
       auth: true,
       username: @user,
     }

--- a/api/config/boot.rb
+++ b/api/config/boot.rb
@@ -44,6 +44,7 @@ end
 
 # Shared activesupport libraries
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/blank'
 
 lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -22,9 +22,7 @@ HTTP/2 200 OK
 
 ## POST - /cloudcmd
 
-Create a new cloudcmd session. Return the `port` the cloudcmd server was started on and the `username`/`password` to access it.
-
-A new `cloudcmd` session will not be created if one already exists for the user. Instead a `409 - Conflict` is returned with the existing details.
+Create a new cloudcmd session. Return the `port` the cloudcmd server was started on and the `password` to access it.
 
 ```
 POST /cloudcmd
@@ -34,24 +32,21 @@ Accepts: application/json
 HTTP/2 201 CREATE
 {
   "port": <integer>,
-  "username": <string>,
   "password": <string>
 }
+```
 
-HTTP/2 409 CONFLICT
-{
-  "port": <integer>,
-  "username": <string>,
-  "password": <string>,
-  "errors": [
-    <conflict-message>
-  ]
-}
+The request MAY specify which directory the file manager should be open at with the `dir` query argument. This SHOULD be a relative path from the user's home directory. It SHOULD NOT use the special file path modifiers (e.g. `.`, `..`, `~`, and etc).
+
+```
+POST /cloudcmd?dir=<relative-path>
+Authorization: Basic <base64 username:password>
+Accepts: application/json
 ```
 
 ## DELETE - /cloudcmd
 
-Destroy an existing cloudcmd session. It SHOULD return `201 - ACCEPTED` or `204 - NO CONTENT` under normal operations. It SHALL return `204 - NO CONTENT` if the session is successfully terminated. It SHOULD return `204 - NO CONTENT` if there is no actively running session. It SHALL return `201 - ACCEPTED` when there is a pre-existing `cloudcmd` session which SHOULD exit after the response has been issued.
+Destroy an existing cloudcmd session. It SHOULD return `201 - ACCEPTED` or `204 - NO CONTENT` under normal operations. It SHALL return `204 - NO CONTENT` if the session has successfully terminated. It SHOULD return `204 - NO CONTENT` if there is no actively running session. It SHALL return `201 - ACCEPTED` when there is a pre-existing `cloudcmd` session which SHOULD exit after the response has been issued.
 
 ```
 DELETE /cloudcmd

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -22,7 +22,10 @@ HTTP/2 200 OK
 
 ## POST - /cloudcmd
 
-Create a new cloudcmd session. Return the `port` the cloudcmd server was started on and the `password` to access it.
+Create a new cloudcmd session. Returns the `password` to access the cloudcmd session and the `url` fragment where it is being
+hosted.
+
+NOTE: The `url` fragment does not contain the hypertext protocol used to access the service. It will need to be prefixed with either `http:` or `https:` before accessing the service.
 
 ```
 POST /cloudcmd
@@ -31,18 +34,23 @@ Accepts: application/json
 
 HTTP/2 201 CREATE
 {
-  "port": <integer>,
-  "password": <string>
+  "password": <string>,
+  "url": <string>
 }
 ```
 
-The request MAY specify which directory the file manager should be open at with the `dir` query argument. This SHOULD be a relative path from the user's home directory. It SHOULD NOT use the special file path modifiers (e.g. `.`, `..`, `~`, and etc).
+The request MAY specify which directory the file manager should be open at with the `dir` query argument. The `dir` MUST be one of the following:
+1. An absolute path to the user's home directory or sub-directories,
+2. A relative path from the user's home directory that meets the first condition when expanded.
+
+`422 Unprocessable Entity` SHALL be returned if the directory is invalid.
 
 ```
 POST /cloudcmd?dir=<relative-path>
 Authorization: Basic <base64 username:password>
 Accepts: application/json
 ```
+
 
 ## DELETE - /cloudcmd
 

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -39,18 +39,17 @@ HTTP/2 201 CREATE
 }
 ```
 
-The request MAY specify which directory the file manager should be open at with the `dir` query argument. The `dir` MUST be one of the following:
+The request MAY specify which directory the file manager should be opened at with the `dir` query argument. The `dir` MUST be one of the following:
 1. An absolute path to the user's home directory or sub-directories,
 2. A relative path from the user's home directory that meets the first condition when expanded.
 
 `422 Unprocessable Entity` SHALL be returned if the directory is invalid.
 
 ```
-POST /cloudcmd?dir=<relative-path>
+POST /cloudcmd?dir=<path>
 Authorization: Basic <base64 username:password>
 Accepts: application/json
 ```
-
 
 ## DELETE - /cloudcmd
 

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -22,10 +22,8 @@ HTTP/2 200 OK
 
 ## POST - /cloudcmd
 
-Create a new cloudcmd session. Returns the `password` to access the cloudcmd session and the `url` fragment where it is being
-hosted.
+Create a new cloudcmd session. Returns the `password` to access the cloudcmd session and the protocol relative `url` to where it is being hosted.
 
-NOTE: The `url` fragment does not contain the hypertext protocol used to access the service. It will need to be prefixed with either `http:` or `https:` before accessing the service.
 
 ```
 POST /cloudcmd

--- a/api/etc/flight-file-manager-api.development.yaml
+++ b/api/etc/flight-file-manager-api.development.yaml
@@ -26,6 +26,8 @@
 #===============================================================================
 
 bind_address: tcp://0.0.0.0:6309
-log_level: debug
-cloudcmd_cookie_name: flight_file_manager_backend_dev
 cloudcmd_cookie_domain: flight.lvh.me
+cloudcmd_cookie_name: flight_file_manager_backend_dev
+cloudcmd_cookie_path: /dev/files/backend
+log_level: debug
+mount_point: /dev/files

--- a/api/lib/flight_file_manager/configuration.rb
+++ b/api/lib/flight_file_manager/configuration.rb
@@ -56,7 +56,7 @@ module FlightFileManager
       {
         name: 'data_dir',
         env_var: true,
-        default: 'usr/share',
+        default: 'var/lib',
         transform: relative_to(root_path)
       },
       {

--- a/api/libexec/cloudcmd.development.sh
+++ b/api/libexec/cloudcmd.development.sh
@@ -27,7 +27,8 @@
 
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 BACKEND="${SCRIPT_DIR}"/../../backend/src/main.js
-NODE=node
-# NODE=.nvm/versions/node/v14.15.4/bin/node
+#NODE=node
+#NODE=.nvm/versions/node/v14.15.4/bin/node
+NODE=/opt/flight/bin/node
 
 "${NODE}" "${BACKEND}" "$@"

--- a/client/.env.development
+++ b/client/.env.development
@@ -1,0 +1,117 @@
+# See the `.env` file for comments.
+PORT=3002
+PUBLIC_URL="/dev/files"
+REACT_APP_MOUNT_PATH="/dev/files"
+
+# ==============================================================================
+# API service configuration
+#
+# The values selected here assume an external proxy.  If developing on
+# [OpenFlight Vagrant
+# Cluster](https://github.com/openflighthpc/openflight-vagrant-cluster) Flight
+# WWW will proxy the requests correctly.
+#
+# If not developing on OpenFlight Vagrant Cluster, you may be best using the
+# alternate configuration below.
+#
+# NOTE:
+# * The `REACT_APP_*_BASE_URL`s can be toggled independently.
+# * `REACT_APP_API_BASE_URL` and `REACT_APP_CONFIG_FILE` must be from the same
+#   section.
+# * You need to restart this project's development server for these changes to
+#   take affect.
+#
+# Development services.
+# REACT_APP_LOGIN_API_BASE_URL="/dev/login/api/v0"
+# REACT_APP_API_BASE_URL="/dev/files/api/v2"
+# REACT_APP_CONFIG_FILE="/dev/files/config.dev.json"
+
+# Production services.  That is those installed via the OS package manager.
+REACT_APP_LOGIN_API_BASE_URL="/login/api/v0"
+REACT_APP_API_BASE_URL="/files/api/v2"
+REACT_APP_CONFIG_FILE="/dev/files/config.prod-services.json"
+# ==============================================================================
+
+# ==============================================================================
+# ALTERNATE API service configuration using Flight File Manager Webapp to proxy
+# requests.
+#
+# Use this section if 1) you are not using OpenFlight Vagrant Cluster; or 2)
+# you are using OpenFlight Vagrant Cluster but wish to avoid using Flight WWW
+# to proxy requests.
+#
+# The server started by `yarn run start` can be used to proxy the requests.
+# The configuration given here does so.
+#
+# NOTE:
+# * The `REACT_APP_PROXY_*_PATH` must match the path in the corresponding
+#   `REACT_APP_*_BASE_URL`.
+# * The URLs are resolved from the machine running Flight File Manager Webapp.
+# * You may need to change hostnames and ports.
+#
+# REACT_APP_API_BASE_URL="/dev/files/api/v2"
+# REACT_APP_CONFIG_FILE="/dev/files/config.dev.json"
+# REACT_APP_PROXY_API="true"
+# REACT_APP_PROXY_API_PATH="/dev/files/api/v2"
+# REACT_APP_PROXY_API_URL="http://flight.lvh.me:6305"
+# REACT_APP_PROXY_API_PATH_REWRITE_FROM="^/dev/files/api"
+# REACT_APP_PROXY_API_PATH_REWRITE_TO="/"
+#
+# REACT_APP_PROXY_CLOUDCMD_API_PATH="/dev/files/backend/:user"
+# REACT_APP_PROXY_CLOUDCMD_API_PATH_REWRITE_FROM="^/dev/files/"
+# REACT_APP_PROXY_CLOUDCMD_API_PATH_REWRITE_TO="/"
+#
+# REACT_APP_LOGIN_API_BASE_URL="/dev/login/api/v0"
+# REACT_APP_PROXY_LOGIN_API="true"
+# REACT_APP_PROXY_LOGIN_API_PATH="/dev/login/api/v0"
+# REACT_APP_PROXY_LOGIN_API_URL="http://flight.lvh.me:6311"
+# REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_FROM="^/dev/login/api/"
+# REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_TO="/"
+# ==============================================================================
+
+# ==============================================================================
+# ALTERNATE API service configuration without any proxying
+#
+# Use this section if 1) you are not using OpenFlight Vagrant Cluster; or 2)
+# you are using OpenFlight Vagrant Cluster but wish to avoid any proxied
+# requests.
+#
+# NOTE:
+# * The URLs given must be absolute.
+# * The services must be confgured to accept CORS.
+# * You will need to create an appropriate config.json for your needs.
+# * You may need to change the `PUBLIC_URL` and `REACT_APP_MOUNT_PATH` or you
+#   may not.
+# * Having the login server on a different host:port may not be well
+#   supported.
+# * This is largely untested, but can be made to work. Your mileage will vary.
+#   Use one of the options above.
+#
+# REACT_APP_API_BASE_URL="http://flight.lvh.me:16305/v2"
+# REACT_APP_LOGIN_API_BASE_URL="http://flight.lvh.me:16311/v0"
+# REACT_APP_CONFIG_FILE="/dev/files/config.custom.json"
+# PUBLIC_URL="/dev/files"
+# REACT_APP_MOUNT_PATH="/dev/files"
+# ==============================================================================
+
+
+# ==============================================================================
+# Configure paths to environment, branding and styles.
+#
+# These values, when used with `openflight-vagrant-cluster`, load the styles
+# from files inside this repo.
+REACT_APP_BRANDING_CSS_URL="/dev/files/styles/branding.css"
+REACT_APP_BRANDING_FILE="/dev/files/data/branding.dev.json"
+REACT_APP_ENVIRONMENT_FILE="/dev/files/data/environment.dev.json"
+#
+# These values, when used with OpenFlight Vagrant Cluster and proxying via
+# Flight WWW, load the styles from the production landing page.
+# REACT_APP_BRANDING_CSS_URL="/styles/branding.css"
+# REACT_APP_BRANDING_FILE="/data/branding.dev.json"
+# REACT_APP_ENVIRONMENT_FILE="/data/environment.dev.json"
+#
+# The values selected here load the styles from some external service.
+# REACT_APP_BRANDING_CSS_URL="http://localhost:3001/styles/branding.css"
+# REACT_APP_BRANDING_FILE="http://localhost:3001/data/branding.dev.json"
+# REACT_APP_ENVIRONMENT_FILE="http://localhost:3001/data/environment.dev.json"
+# ==============================================================================

--- a/client/public/config.dev.json
+++ b/client/public/config.dev.json
@@ -1,6 +1,3 @@
 {
-  "clusterName": "File Manager Test",
-  "clusterDescription": "A description of this cluster.",
-  "clusterLogo": "https://s3.eu-west-2.amazonaws.com/alces-flight-center/logos/Alces_flight_logo_horiz.png",
-  "apiRootUrl": "/files/api/v0"
+  "apiRootUrl": "/dev/files/api/v0"
 }

--- a/client/public/config.prod-services.json
+++ b/client/public/config.prod-services.json
@@ -1,0 +1,3 @@
+{
+  "apiRootUrl": "/files/api/v0"
+}

--- a/client/public/data/branding.dev.json
+++ b/client/public/data/branding.dev.json
@@ -1,16 +1,16 @@
 {
   "brandbar": {
     "logo": {
-      "url": "/job-scripts/bigv-uni-50x50.png",
+      "url": "/dev/files/images/bigv-uni-50x50.png",
       "alt": "BigV dev env logo",
       "classNames": "foo"
     },
-    "text": "University of BigV"
+    "text": ""
   },
   "apps": {
     "dashboard": {
       "logo": {
-        "url": "/job-scripts/bigv-uni.png",
+        "url": "/dev/files/images/bigv-uni.png",
         "alt": "BigV dev env logo",
         "classNames": "mb-4"
       }

--- a/client/public/data/environment.dev.json
+++ b/client/public/data/environment.dev.json
@@ -1,13 +1,13 @@
 {
   "environment": {
-    "name": "University of BigV dev env",
-    "description": "This is a dev environment for the University of BigV.",
+    "name": "Dev cluster",
+    "description": "This is a dev environment.",
     "logo": {
       "url": "",
       "classNames": ""
     }
   },
   "organisation": {
-    "name": "University of BigV"
+    "name": ""
   }
 }

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef } from 'react';
 import useFetch from 'use-http';
+import { useLocation } from "react-router-dom";
 
 import { CurrentUserContext } from 'flight-webapp-components';
 
@@ -56,8 +57,16 @@ function useAuthCheck() {
 }
 
 export function useLaunchSession() {
+  const dir = new URLSearchParams(useLocation().search).get('dir')
+  var path
+  if (dir) {
+    path = `/cloudcmd?dir=${dir}`;
+  } else {
+    path = "/cloudcmd";
+  }
+
   const request = useFetch(
-    "/cloudcmd",
+    path,
     {
       method: 'post',
       headers: {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useRef } from 'react';
 import useFetch from 'use-http';
-import { useLocation } from "react-router-dom";
 
 import { CurrentUserContext } from 'flight-webapp-components';
 
@@ -56,8 +55,7 @@ function useAuthCheck() {
     });
 }
 
-export function useLaunchSession() {
-  const dir = new URLSearchParams(useLocation().search).get('dir')
+export function useLaunchSession(dir) {
   var path
   if (dir) {
     path = `/cloudcmd?dir=${dir}`;

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,41 +1,63 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
-  // Proxy requests to the supervisor.
-  app.use(
-    '/files/api/v0',
-    createProxyMiddleware({
-      target: 'http://localhost:6309',
-      changeOrigin: false,
-      pathRewrite: {
-        '^/files/api/': '/', // Remove base path.
-      },
-      logLevel: 'debug',
-    })
-  );
+  if (process.env.REACT_APP_PROXY_API === "true") {
+    // Proxy requests to the file manager.
 
-  // Proxy requests to the cloudcmd backend.
-  app.use(
-    '/files/backend/:user',
-    createProxyMiddleware({
-      target: 'http://localhost:6309',
-      changeOrigin: false,
-      pathRewrite: {
-        '^/files/': '/',
-      },
-      logLevel: 'debug',
-    })
-  );
+    let rewriteFrom = process.env.REACT_APP_PROXY_API_PATH_REWRITE_FROM ||
+      '^/dev/files/api';
+    let rewriteTo = process.env.REACT_APP_PROXY_API_PATH_REWRITE_TO ||
+      '/';
 
-  app.use(
-    '/login/api/v0',
-    createProxyMiddleware({
-      target: 'http://localhost:6311',
-      changeOrigin: false,
-      pathRewrite: {
-        '^/login/api/': '/', // Remove base path.
-      },
-      logLevel: 'debug',
-    })
-  );
+    app.use(
+      process.env.REACT_APP_PROXY_API_PATH || '/dev/files/api/v0',
+      createProxyMiddleware({
+        target: process.env.REACT_APP_PROXY_API_URL || 'http://localhost:6309',
+        changeOrigin: false,
+        pathRewrite: {
+          [rewriteFrom]: rewriteTo,
+        },
+        logLevel: 'debug',
+      })
+    );
+
+    // Proxy requests to the cloudcmd backend.
+
+    rewriteFrom = process.env.REACT_APP_PROXY_CLOUDCMD_API_PATH_REWRITE_FROM ||
+      '^/dev/files/';
+    rewriteTo = process.env.REACT_APP_PROXY_CLOUDCMD_API_PATH_REWRITE_TO ||
+      '/';
+    app.use(
+      process.env.REACT_APP_PROXY_CLOUDCMD_API_PATH || '/dev/files/backend/:user',
+      createProxyMiddleware({
+        target: process.env.REACT_APP_PROXY_API_URL || 'http://localhost:6309',
+        changeOrigin: false,
+        pathRewrite: {
+          [rewriteFrom]: rewriteTo,
+        },
+        logLevel: 'debug',
+      })
+    );
+  }
+
+  if (process.env.REACT_APP_PROXY_LOGIN_API === "true") {
+    // Proxy requests to the login api.
+
+    const rewriteFrom = process.env.REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_FROM ||
+      '^/dev/login/api';
+    const rewriteTo = process.env.REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_TO ||
+      '/';
+
+    app.use(
+      process.env.REACT_APP_PROXY_LOGIN_API_PATH || '/login/api/v0',
+      createProxyMiddleware({
+        target: process.env.REACT_APP_PROXY_LOGIN_API_URL || 'http://localhost:6311',
+        changeOrigin: false,
+        pathRewrite: {
+          [rewriteFrom]: rewriteTo,
+        },
+        logLevel: 'debug',
+      })
+    );
+  }
 };

--- a/client/src/useFileManager.js
+++ b/client/src/useFileManager.js
@@ -35,6 +35,10 @@ export default function useFileManager(containerRef) {
         urlRef.current = responseBody.url;
         containerRef.current.onload = (event) => { handleOnLoad(event, setTerminalState); }
         containerRef.current.src = responseBody.url;
+        // NOTE: useHistory is intentionally not used as it triggers a page reload.
+        //       This requires either the API or client to remember the previously
+        //       submitted directory. Either option causes undesirable behaviour
+        window.history.replaceState(null, "", `${process.env.REACT_APP_MOUNT_PATH}/browse`);
       }
     });
 


### PR DESCRIPTION
It is now possible to open the file manager at a given directory.

---

Server Side:

The underlying `cloudcmd` library provides a `fs` mount point which allows arbitrary directories to be opened. This means no new configuration is required to support this feature. Instead the `dir` argument provided to the API is reflected back  to the client:

```
> POST /v0/cloudcmd?dir=%2Ftmp%2Ffoobar HTTP/1.1
< HTTP/1.1 200 OK
{
  "password": "45sW5giJ",
  "url": "//192.168.101.3:6309/files/backend/centos/fs/tmp/foobar"
}
```

**Other Change: data_dir**

There was a *bug* where the `data_dir` defaulted to `usr/share`, which prevented me from finding the configuration files without digging through the code base. The idiomatic location for internal runtime application data files is `var/lib`. The `usr/share` directory should be reserved for user facing/ read-only files.

---

Client Side:

The client now accepts an optional `dir` query argument on the `/files/browse` route.  This is passed onto the API accordingly:

```
/files/browse?dir=...
```

After sending the request, the client's history is updated to remove the `dir` from the query string. This prevents it from getting out of sync with `cloudcmd`.

NOTE: This had to be implemented manually using the `window.history` element as the react `useHistory` hook triggers page reloads. This has been tested in `chrome` but should be configured in other browsers. 