### PR TITLE
Allow file in params

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ optional and can be achieved by editing the `flight-file-manager.yaml` file in
 the `etc/` subdirectory of the tool.  [The file](etc/flight-file-manager.yaml)
 is well documented and outlines all the configuration values available.
 
+By default, the Flight File Manager uses the production version of the API that is installed. To use the development version of the API:
+
+Build the development version of the backend:
+```
+cd flight-file-manager/backend/lib/cloudcmd
+/opt/flight/bin/yarn install
+/opt/flight/bin/yarn run build
+```
+
+Set up the development version of the API:
+```
+cd flight-file-manager/api/
+sudo /opt/flight/bin/bundle install
+sudo /opt/flight/bin/ruby ./bin/puma
+```
+
 ## Operation
 
 ### When installed with Flight Runway

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Flight File Manager allows you to access your HPC environment files via a GUI
 
 ### From source
 
-XXX TBC
+Flight File Manager consists of three separate components: [browser
+client](client), [API process](api) and [per-user backend process](backend).
+The installation instructions for each component can be found in its readme.
 
 ### Installing with Flight Runway
 
@@ -94,22 +96,6 @@ For Flight File Manager API, making changes to the default configuration is
 optional and can be achieved by editing the `flight-file-manager.yaml` file in
 the `etc/` subdirectory of the tool.  [The file](etc/flight-file-manager.yaml)
 is well documented and outlines all the configuration values available.
-
-By default, the Flight File Manager uses the production version of the API that is installed. To use the development version of the API:
-
-Build the development version of the backend:
-```
-cd flight-file-manager/backend/lib/cloudcmd
-/opt/flight/bin/yarn install
-/opt/flight/bin/yarn run build
-```
-
-Set up the development version of the API:
-```
-cd flight-file-manager/api/
-sudo /opt/flight/bin/bundle install
-sudo /opt/flight/bin/ruby ./bin/puma
-```
 
 ## Operation
 

--- a/api/README.md
+++ b/api/README.md
@@ -4,18 +4,39 @@ Supervisor process for Flight File Manager.  The supervisor starts and stops
 Flight File Manager backend processes and proxies requests from the client to
 the backend.
 
-See [the main README](README.md) for more details.
+See [the main README](/README.md) for more details.
+
+# Installation
+
+## From source
+
+Flight Desktop RestAPI requires a recent version of Ruby and `bundler`.
+
+The following will install from source using `git`:
+
+```
+git clone https://github.com/alces-flight/flight-file-manager.git
+cd flight-file-manager/api
+bundle config set --local with default
+bundle config set --local without development test pry
+bundle config set --local path vendor
+bin/bundle install
+```
+
+## Installing with Flight Runway
+
+See details in [the main README](/README.md).
 
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull
 request. Bonus points for topic branches.
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Read [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.
 
 # Copyright and License
 
-Eclipse Public License 2.0, see [LICENSE.txt](LICENSE.txt) for details.
+Eclipse Public License 2.0, see [LICENSE.txt](/LICENSE.txt) for details.
 
 Copyright (C) 2021-present Alces Flight Ltd.
 

--- a/api/app/cloudcmd.rb
+++ b/api/app/cloudcmd.rb
@@ -74,9 +74,9 @@ class CloudCmd
   def running?
     return false if pid.nil?
     begin
-      Process.getpgid(pid)
+      Process.waitpid(pid, Process::WNOHANG)
       true
-    rescue Errno::ESRCH
+    rescue Errno::ECHILD
       false
     end
   end

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,18 +1,54 @@
 # Flight File Manager Backend
 
 Backend for Flight File Manager.  This serves the file management requests
-from the client.  See [the main README](README.md) for more details.
+from the client.  See [the main README](/README.md) for more details.
+
+# Installation
+
+## From source
+
+Flight File Manager backend requires a recent version of Node and `yarn`.
+
+The following will install from source using `git`.
+
+* Checkout the source code:
+
+```
+git clone https://github.com/alces-flight/flight-file-manager.git
+```
+
+* Build the `cloudcmd` library:
+
+```
+cd flight-file-manager/backend/lib/cloudcmd
+yarn install
+yarn run build
+```
+
+* Build the per-user backend:
+
+```
+cd flight-file-manager/backend
+yarn install
+```
+
+The per-user backend will be started by the [API process](/api) as and when it
+is required.
+
+## Installing with Flight Runway
+
+See details in [the main README](/README.md).
 
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull
 request. Bonus points for topic branches.
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Read [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.
 
 # Copyright and License
 
-Eclipse Public License 2.0, see [LICENSE.txt](LICENSE.txt) for details.
+Eclipse Public License 2.0, see [LICENSE.txt](/LICENSE.txt) for details.
 
 Copyright (C) 2021-present Alces Flight Ltd.
 

--- a/backend/lib/cloudcmd/client/cloudcmd.js
+++ b/backend/lib/cloudcmd/client/cloudcmd.js
@@ -35,7 +35,7 @@ module.exports = window.CloudCmd = async (config) => {
     
     const prefix = getPrefix(config.prefix);
     
-    window.CloudCmd.init(prefix, config);
+    await window.CloudCmd.init(prefix, config);
 };
 
 function getPrefix(prefix) {

--- a/client/README.md
+++ b/client/README.md
@@ -1,18 +1,43 @@
 # Flight File Manager Client
 
-Browser client for Flight File Manager.  See [the main README](README.md)
+Browser client for Flight File Manager.  See [the main README](/README.md)
 for more details.
+
+# Installation
+
+## From source
+
+Flight File Manager Webapp requires a recent version of Node and `yarn`.
+
+The following will install from source using `git`:
+
+```
+git clone https://github.com/alces-flight/flight-file-manager.git
+cd flight-file-manager/client
+yarn install
+yarn run build
+```
+
+Flight File Manager Webapp has been built into `build/`.  It can be served by
+any webserver configured to serve static files from that directory.  By
+default, Flight File Manager Webapp expects to be served from a path of
+`/files`.  If that does not suit your needs, see the configuration section
+below for details on how to configure it.
+
+## Installing with Flight Runway
+
+See details in [the main README](/README.md).
 
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull
 request. Bonus points for topic branches.
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Read [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.
 
 # Copyright and License
 
-Eclipse Public License 2.0, see [LICENSE.txt](LICENSE.txt) for details.
+Eclipse Public License 2.0, see [LICENSE.txt](/LICENSE.txt) for details.
 
 Copyright (C) 2021-present Alces Flight Ltd.
 

--- a/client/src/useFileManager.js
+++ b/client/src/useFileManager.js
@@ -112,13 +112,14 @@ export default function useFileManager() {
         const file = sessionRef.current.file;
         debug('Loading directory %s', dir);
         window.CloudCmd.addListener('current-file', currentFileListener);
-        window.CloudCmd.loadDir({path: dir}).then(() => {
-          if (file) {
-            debug("loading file %s", file);
-            window.DOM.setCurrentByName(file);
-            window.CloudCmd.View.show();
-          }
-        });
+        window.CloudCmd.loadDir({path: dir})
+          .then(() => {
+            if (file) {
+              debug("Displaying file %s", file);
+              window.DOM.setCurrentByName(file);
+              window.CloudCmd.View.show();
+            }
+          });
         setState('connected');
         clearSearchParams();
       };

--- a/client/src/useFileManager.js
+++ b/client/src/useFileManager.js
@@ -81,6 +81,7 @@ export default function useFileManager() {
         sessionRef.current = {
           url: responseBody.url,
           dir: responseBody.dir,
+          file: responseBody.file
         };
         debug('Retrieving assets %s', sessionRef.current.url);
         setState('retrieving');
@@ -108,16 +109,16 @@ export default function useFileManager() {
     if (state === 'retrieved') {
       const onConnected = () => {
         const dir = sessionRef.current.dir || '/';
+        const file = sessionRef.current.file;
         debug('Loading directory %s', dir);
         window.CloudCmd.addListener('current-file', currentFileListener);
-        window.CloudCmd.loadDir({path: dir});
-        // XXX Add this in properly.
-        // .then(() => {
-        //   if (true) {
-        //     window.DOM.setCurrentByName('stuff.md');
-        //     setTimeout(() => window.CloudCmd.View.show(), 0)
-        //   }
-        // });
+        window.CloudCmd.loadDir({path: dir}).then(() => {
+          if (file) {
+            debug("loading file %s", file);
+            window.DOM.setCurrentByName(file);
+            window.CloudCmd.View.show();
+          }
+        });
         setState('connected');
         clearSearchParams();
       };


### PR DESCRIPTION
This PR introduces the ability to provide a filename via the `?dir=` URL parameter. If the file exists, File Manager will navigate to its directory and attempt to view it. Note that currently, the application has an irregularly occurring error regarding file permissions. If the user cannot view the file, the application may raise an unhandled `Internal server error`. This is outside of the scope of this PR, and will be left for the future.

An update to the README has been included in this PR to describe how to set up the development versions of the backend/API.