### PR TITLE
Add menu for bookmarked directories

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -98,6 +98,7 @@ class App < Sinatra::Base
       {
         dir: dir || cloudcmd.default_dir,
         file: file,
+        home_dir: cloudcmd.default_dir,
         url: "//#{request.host}:#{port}#{url_path}"
       }.to_json
     end

--- a/api/app.rb
+++ b/api/app.rb
@@ -76,7 +76,7 @@ class App < Sinatra::Base
 
     def dir_and_file(cloudcmd)
       if params["dir"].present?
-        path = Pathname.new(params["dir"]).expand_path(cloudcmd.default_dir)
+        path = Pathname.new(params["dir"]).expand_path(cloudcmd.home_dir)
         begin
           path.realpath
         rescue Errno::ENOENT
@@ -96,9 +96,9 @@ class App < Sinatra::Base
       port = request.port if port.nil? || port == ""
       dir, file = dir_and_file(cloudcmd)
       {
-        dir: dir || cloudcmd.default_dir,
+        dir: dir || cloudcmd.home_dir,
         file: file,
-        home_dir: cloudcmd.default_dir,
+        home_dir: cloudcmd.home_dir,
         url: "//#{request.host}:#{port}#{url_path}"
       }.to_json
     end

--- a/api/app/cloudcmd.rb
+++ b/api/app/cloudcmd.rb
@@ -118,8 +118,8 @@ class CloudCmd
     end
   end
 
-  def default_dir
-    @default_dir ||= Etc.getpwnam(@user).dir
+  def home_dir
+    @home_dir ||= Etc.getpwnam(@user).dir
   end
 
   def root_dir

--- a/client/README.md
+++ b/client/README.md
@@ -32,20 +32,31 @@ See details in [the main README](/README.md).
 
 ## Bookmarks/common directories
 
-At the moment, bookmarks are specified in the `REACT_APP_DATA_FILE`. To create a new bookmark, add a new JSON entry to the `bookmarks` array of the form:
+At the moment, bookmarks are specified in the `REACT_APP_DATA_FILE`. To create
+a new bookmark, add a new JSON entry to the `bookmarks` array of the form:
 
 ```json
 {
   "bookmarks": [
     {
       "path": "Desktop/",
-      "text": "Desktop"
+      "text": "Desktop",
+      "fa_icon": "desktop"
     }
   ]
 }
 ```
 
-Where `path` is the path to the directory, and `text` is the text used for the dropdown menu item. Include a preceding `/` to the `path` value to make the path absolute; omit it to make the path relative to the user's home directory.
+Where `path` is the path to the directory; `text` is the text used for the
+dropdown menu item; and `fa_icon` is optional and if given the name of Font
+Awesome icon to use.
+
+If the path is a relative path (i.e., it does not begin with `/`) it is
+relative to the user's home directory.
+
+There is currently a known issue where if the bookmark path matches a file
+instead of a directory, the File Manager will become unresponsive until it is
+reloaded.
 
 # Contributing
 

--- a/client/README.md
+++ b/client/README.md
@@ -28,6 +28,25 @@ below for details on how to configure it.
 
 See details in [the main README](/README.md).
 
+# Configuration
+
+## Bookmarks/common directories
+
+At the moment, bookmarks are specified in the `REACT_APP_DATA_FILE`. To create a new bookmark, add a new JSON entry to the `bookmarks` array of the form:
+
+```json
+{
+  "bookmarks": [
+    {
+      "path": "Desktop/",
+      "text": "Desktop"
+    }
+  ]
+}
+```
+
+Where `path` is the path to the directory, and `text` is the text used for the dropdown menu item. Include a preceding `/` to the `path` value to make the path absolute; omit it to make the path relative to the user's home directory.
+
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull

--- a/client/README.md
+++ b/client/README.md
@@ -30,15 +30,38 @@ See details in [the main README](/README.md).
 
 # Configuration
 
-## Bookmarks/common directories
+## When installed with Flight Runway
 
-At the moment, bookmarks are specified in the `REACT_APP_DATA_FILE`. To create
-a new bookmark, add a new JSON entry to the `bookmarks` array of the form:
+When Flight File Manager Webapp is installed with Flight Runway, configuration
+is provided through [Flight Landing
+page](https://github.com/openflighthpc/flight-landing-page).  See the
+README.md file in that repo for details.
+
+## When installed form source
+
+When Flight File Manager Webapp is installed from source, the configuration is
+loaded from URLs which are set via environment variables when the application
+is built.  These environment variables are set and documented in the `.env`
+file.
+
+Example configuration files can be found in the [public](public/) directory.
+In particular, the [public/data](public/data/) and
+[public/styles](public/styles) directories.
+
+
+## Bookmarks
+
+Bookmarks are specified in the JSON file loaded from the URL given by
+`REACT_APP_DATA_FILE`, defaulting to `/data/index.json`.
+
+To create a new bookmark, add a new JSON entry to the `bookmarks` array in the
+form:
 
 ```json
 {
   "bookmarks": [
     {
+      "id": "desktop",
       "path": "Desktop/",
       "text": "Desktop",
       "fa_icon": "desktop"
@@ -47,13 +70,10 @@ a new bookmark, add a new JSON entry to the `bookmarks` array of the form:
 }
 ```
 
-Where `path` is the path to the directory; `text` is the text used for the
-dropdown menu item; and `fa_icon` is optional and if given the name of Font
-Awesome icon to use.
-
-If the `REACT_APP_DATA_FILE` is created/managed by a Flight Landing Page
-installation, you should modify the `bookmarks.yaml` file present in the 
-landing page.
+Where `id` is a unique identifier for the bookmark; `path` is the relative or
+absolute path to the directory; `text` is the text used for the dropdown menu
+item; and `fa_icon` is optional and if given the name of Font Awesome icon to
+use.
 
 If the path is a relative path (i.e., it does not begin with `/`) it is
 relative to the user's home directory.

--- a/client/README.md
+++ b/client/README.md
@@ -51,6 +51,10 @@ Where `path` is the path to the directory; `text` is the text used for the
 dropdown menu item; and `fa_icon` is optional and if given the name of Font
 Awesome icon to use.
 
+If the `REACT_APP_DATA_FILE` is created/managed by a Flight Landing Page
+installation, you should modify the `bookmarks.yaml` file present in the 
+landing page.
+
 If the path is a relative path (i.e., it does not begin with `/`) it is
 relative to the user's home directory.
 

--- a/client/public/data/index.dev.json
+++ b/client/public/data/index.dev.json
@@ -26,16 +26,19 @@
   "sidebar" : "<aside class=\"sidenav col-12 col-md-3 col-lg-2\">\n  <div>\n    \n\n    \n\n    \n\n    \n\n    \n      <h2>Quick Access</h2>\n      <ul class=\"w-100\">\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/console\">Console (Dev)</a>\n          </li>\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/desktop\">Desktop (Dev)</a>\n          </li>\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/files\">File Manager (Dev)</a>\n          </li>\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/job-scripts\">Job Scripts (Dev)</a>\n          </li>\n        \n      </ul>\n    \n  </div>\n</aside>\n",
   "bookmarks": [
     {
+      "id": "desktop",
       "path": "Desktop/",
       "text": "Desktop",
       "fa_icon": "desktop"
     },
     {
+      "id": "documents",
       "path": "Documents/",
       "text": "Documents",
       "fa_icon": "file-text-o"
     },
     {
+      "id": "site-data",
       "path": "/opt/site/",
       "text": "Site data"
     }

--- a/client/public/data/index.dev.json
+++ b/client/public/data/index.dev.json
@@ -1,0 +1,16 @@
+{
+  "bookmarks": [
+    {
+      "path": "Desktop/",
+      "text": "Desktop"
+    },
+    {
+      "path": "Documents/",
+      "text": "Documents"
+    },
+    {
+      "path": "job-1.output",
+      "text": "Users"
+    }
+  ]
+}

--- a/client/public/data/index.dev.json
+++ b/client/public/data/index.dev.json
@@ -1,16 +1,43 @@
 {
+  "home_link" : {
+    "path": "/dev/",
+    "text": "Home"
+  },
+  "apps_link" : {
+    "path": "/dev/apps",
+    "text": "Apps"
+  },
+  "config_packs_link" : {
+    "path": "/dev/config-packs",
+    "text": "Config Packs"
+  },
+  "apps" : 
+    [
+      {"title":"Flight Console Service (Dev)","short_title":"Console (Dev)","subtitle":"Access interactive console sessions","path":"/dev/console","fa_icon":"terminal"}
+    
+    , {"title":"Flight Desktop Access Service (Dev)","short_title":"Desktop (Dev)","subtitle":"Access interactive GUI desktop sessions","path":"/dev/desktop","fa_icon":"desktop"}
+    
+    , {"title":"Flight File Manager Access Service (Dev)","short_title":"File Manager (Dev)","subtitle":"Access file manager sessions","path":"/dev/files","fa_icon":"file-o"}
+    
+    , {"title":"Flight Job Script Service (Dev)","short_title":"Job Scripts (Dev)","subtitle":"Create customised job scripts from templates","path":"/dev/job-scripts","fa_icon":"file-code-o"}
+    ],
+  "config_packs" :
+    [],
+  "sidebar" : "<aside class=\"sidenav col-12 col-md-3 col-lg-2\">\n  <div>\n    \n\n    \n\n    \n\n    \n\n    \n      <h2>Quick Access</h2>\n      <ul class=\"w-100\">\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/console\">Console (Dev)</a>\n          </li>\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/desktop\">Desktop (Dev)</a>\n          </li>\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/files\">File Manager (Dev)</a>\n          </li>\n        \n          <li>\n            <a data-http-strike-disable=\"\" data-http-add-title=\"Flight Web Suite requires HTTPS to be enabled\" href=\"/dev/job-scripts\">Job Scripts (Dev)</a>\n          </li>\n        \n      </ul>\n    \n  </div>\n</aside>\n",
   "bookmarks": [
     {
       "path": "Desktop/",
-      "text": "Desktop"
+      "text": "Desktop",
+      "fa_icon": "desktop"
     },
     {
       "path": "Documents/",
-      "text": "Documents"
+      "text": "Documents",
+      "fa_icon": "file-text-o"
     },
     {
-      "path": "job-1.output",
-      "text": "Users"
+      "path": "/opt/site/",
+      "text": "Site data"
     }
   ]
 }

--- a/client/src/FileManager.module.css
+++ b/client/src/FileManager.module.css
@@ -31,4 +31,6 @@
     display: inline-block;
     width: 14px;
 }
-
+.DropdownItem .fa {
+    width: 1rem;
+}

--- a/client/src/FileManager.module.css
+++ b/client/src/FileManager.module.css
@@ -33,4 +33,5 @@
 }
 .DropdownItem .fa {
     width: 1rem;
+    text-align: center;
 }

--- a/client/src/Toolbar.js
+++ b/client/src/Toolbar.js
@@ -59,11 +59,21 @@ function BookmarkButtons() {
     </DropdownItem>
   );
 
+  const disabled = bookmarks.length === 0;
+  const title = (disabled) ? "No bookmarked directories" : "Go to a bookmarked directory"
+
   return (
     <UncontrolledDropdown
       className="btn-group mr-2"
     >
-      <DropdownToggle split color="light" size="sm" caret>
+      <DropdownToggle
+        color="light"
+        size="sm" 
+        title={title}
+        disabled={disabled}
+        caret
+        split
+      >
         <i className="fa fa-bookmark mr-2" />
       </DropdownToggle>
       <DropdownMenu>

--- a/client/src/Toolbar.js
+++ b/client/src/Toolbar.js
@@ -44,11 +44,20 @@ function ActionButtons() {
 };
 
 function BookmarkButtons() {
+  const { navigate } = useContext(FileManagerContext);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const toggleDropdown = () => setDropdownOpen(prevState => !prevState);
 
   const data = useData()
   const bookmarks = data("bookmarks")
+  const items = bookmarks.map(item =>
+    <DropdownItem
+      onClick={() => {navigate({path: item.path})}}
+      key={item.path}
+    >
+      {item.text}
+    </DropdownItem>
+  );
 
   return (
     <Dropdown
@@ -60,7 +69,9 @@ function BookmarkButtons() {
         <i className="fa fa-bookmark mr-2" />
       </DropdownToggle>
       <DropdownMenu>
-        {/* DROPDOWN ITEMS GO HERE */}
+        {
+          items
+        }
       </DropdownMenu>
     </Dropdown>
   );

--- a/client/src/Toolbar.js
+++ b/client/src/Toolbar.js
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
-import { Button, ButtonGroup } from 'reactstrap';
-import { useContext } from 'react';
+import { Button, ButtonGroup, Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
+import { useContext, useState } from 'react';
 
 import {
   FullscreenButton,
+  useData,
 } from 'flight-webapp-components';
 
 import { Context as FileManagerContext } from './FileManagerContext';
@@ -35,11 +36,35 @@ function ActionButtons() {
     <UpDownloadButtons />
     <TarballButtons />
     <SelectionButtons />
+    <BookmarkButtons />
     </>
   );
 
   return actions;
 };
+
+function BookmarkButtons() {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const toggleDropdown = () => setDropdownOpen(prevState => !prevState);
+
+  const data = useData()
+  const bookmarks = data("bookmarks")
+
+  return (
+    <Dropdown
+      className="btn-group mr-2"
+      isOpen={dropdownOpen}
+      toggle={toggleDropdown}
+    >
+      <DropdownToggle split color="light" size="sm" caret>
+        <i className="fa fa-bookmark mr-2" />
+      </DropdownToggle>
+      <DropdownMenu>
+        {/* DROPDOWN ITEMS GO HERE */}
+      </DropdownMenu>
+    </Dropdown>
+  );
+}
 
 function NavButtons() {
   const { goToParentDir, isRootDir } = useContext(FileManagerContext);

--- a/client/src/Toolbar.js
+++ b/client/src/Toolbar.js
@@ -52,10 +52,12 @@ function BookmarkButtons() {
 
   const items = bookmarks.map(item =>
     <DropdownItem
+      className={styles.DropdownItem}
       onClick={() => {navigate({path: item.path})}}
       key={item.path}
     >
-      {item.text}
+      <span className={classNames(`fa fa-${item.fa_icon} mr-2`, styles.fa)} />
+      <span className="title">{item.text}</span>
     </DropdownItem>
   );
 

--- a/client/src/Toolbar.js
+++ b/client/src/Toolbar.js
@@ -49,7 +49,9 @@ function BookmarkButtons() {
   const toggleDropdown = () => setDropdownOpen(prevState => !prevState);
 
   const data = useData()
-  const bookmarks = data("bookmarks")
+  var bookmarks = data("bookmarks")
+  bookmarks = (bookmarks == null || !Array.isArray(bookmarks)) ? [] : bookmarks;
+
   const items = bookmarks.map(item =>
     <DropdownItem
       onClick={() => {navigate({path: item.path})}}

--- a/client/src/Toolbar.js
+++ b/client/src/Toolbar.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
-import { Button, ButtonGroup, Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
-import { useContext, useState } from 'react';
+import { Button, ButtonGroup, UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
+import { useContext } from 'react';
 
 import {
   FullscreenButton,
@@ -45,8 +45,6 @@ function ActionButtons() {
 
 function BookmarkButtons() {
   const { navigate } = useContext(FileManagerContext);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const toggleDropdown = () => setDropdownOpen(prevState => !prevState);
 
   const data = useData()
   var bookmarks = data("bookmarks")
@@ -62,10 +60,8 @@ function BookmarkButtons() {
   );
 
   return (
-    <Dropdown
+    <UncontrolledDropdown
       className="btn-group mr-2"
-      isOpen={dropdownOpen}
-      toggle={toggleDropdown}
     >
       <DropdownToggle split color="light" size="sm" caret>
         <i className="fa fa-bookmark mr-2" />
@@ -75,7 +71,7 @@ function BookmarkButtons() {
           items
         }
       </DropdownMenu>
-    </Dropdown>
+    </UncontrolledDropdown>
   );
 }
 

--- a/client/src/useFileManager.js
+++ b/client/src/useFileManager.js
@@ -81,7 +81,7 @@ export default function useFileManager() {
         sessionRef.current = {
           url: responseBody.url,
           dir: responseBody.dir,
-          home_dir: responseBody.home_dir,
+          homeDir: responseBody.home_dir,
           file: responseBody.file
         };
         debug('Retrieving assets %s', sessionRef.current.url);
@@ -159,7 +159,7 @@ export default function useFileManager() {
     if (state === 'connected') {
       const path = (dir.path.startsWith('/')) ?
         dir.path :
-        sessionRef.current.home_dir + '/' + dir.path
+        sessionRef.current.homeDir + '/' + dir.path
 
       window.CloudCmd.loadDir({path: path});
     }

--- a/client/src/useFileManager.js
+++ b/client/src/useFileManager.js
@@ -53,16 +53,6 @@ export default function useFileManager() {
   // * `failed`: something went wrong.
   const [ state, setState ] = useState('launching');
 
-  const navigate = useCallback((dir) => {
-    if (state === 'connected') {
-      const path = (dir.path.startsWith('/')) ?
-        dir.path :
-        sessionRef.current.home_dir + '/' + dir.path
-
-      window.CloudCmd.loadDir({path: path});
-    }
-  }, [state]);
-
   const currentFileListener = useCallback(() => {
     setTimeout(() => {
       const Info = window.DOM.CurrentInfo;
@@ -164,6 +154,16 @@ export default function useFileManager() {
   function pack()          { if (state === 'connected') { window.CloudCmd.Operation.show('pack'); } };
   function extract()       { if (state === 'connected') { window.CloudCmd.Operation.show('extract'); } };
   function toggleAllSelectedFiles() { if (state === 'connected') { window.DOM.toggleAllSelectedFiles(); } };
+
+  const navigate = useCallback((dir) => {
+    if (state === 'connected') {
+      const path = (dir.path.startsWith('/')) ?
+        dir.path :
+        sessionRef.current.home_dir + '/' + dir.path
+
+      window.CloudCmd.loadDir({path: path});
+    }
+  }, [state]);
 
   return {
     goToParentDir: useCallback(goToParentDir, [state]),

--- a/client/src/useFileManager.js
+++ b/client/src/useFileManager.js
@@ -53,6 +53,16 @@ export default function useFileManager() {
   // * `failed`: something went wrong.
   const [ state, setState ] = useState('launching');
 
+  const navigate = useCallback((dir) => {
+    if (state === 'connected') {
+      const path = (dir.path.startsWith('/')) ?
+        dir.path :
+        sessionRef.current.home_dir + '/' + dir.path
+
+      window.CloudCmd.loadDir({path: path});
+    }
+  }, [state]);
+
   const currentFileListener = useCallback(() => {
     setTimeout(() => {
       const Info = window.DOM.CurrentInfo;
@@ -81,6 +91,7 @@ export default function useFileManager() {
         sessionRef.current = {
           url: responseBody.url,
           dir: responseBody.dir,
+          home_dir: responseBody.home_dir,
           file: responseBody.file
         };
         debug('Retrieving assets %s', sessionRef.current.url);
@@ -175,5 +186,6 @@ export default function useFileManager() {
     isFileSelected,
     isRootDir,
     state,
+    navigate
   };
 }


### PR DESCRIPTION
This PR adds some basic functionality for defining and accessing directories commonly used by Flight File Manager users.

## Bookmark specification

At the moment, bookmarks are specified in the `REACT_APP_DATA_FILE`. A sample `bookmarks` key resembles the following:

```
{
  "bookmarks": [
    {
      "path": "Desktop/",
      "text": "Desktop"
    },
    {
      "path": "Documents/",
      "text": "Documents"
    },
    {
      "path": "/home",
      "text": "Users"
    }
  ]
}
```

For each entry in `bookmarks`:
- The `path` key specifies the path to the desired directory.
  -  If the path starts with a `/`, it will be treated as an absolute path. Otherwise, it will be evaluated as relative to the logged in user's home directory.
- The `text` key specifies what should be displayed on the bookmark's dropdown item.

## Front-end details

A new dropdown button has been added to the File Manager toolbar to access the bookmarks.
![Screenshot_2022-05-25_16-07-51](https://user-images.githubusercontent.com/12374447/170296264-cd4eda17-32ff-4c0f-b725-ca89c8f1c59d.png)

The following screenshot uses the sample `bookmarks` entry used above:
![Screenshot_2022-05-25_16-11-29](https://user-images.githubusercontent.com/12374447/170296414-0f236ce1-13f0-48dc-8d02-71e3c40913b2.png)

## Future plans

Some next steps for this functionality include:
- Allowing the user to define their own bookmarks
- Allowing the user to hide the cluster admin defined bookmarks
- Allowing files to be specified as bookmarks
- Adding support for placeholder values in the bookmark specification
  - For example, a user may want to access a directory at `/scratch/<username>`, but shouldn't be allowed access to any other subdirectories in `/scratch`.
