### PR TITLE
Fix memory leak in backend proxying

### DIFF
--- a/api/config.ru
+++ b/api/config.ru
@@ -52,7 +52,8 @@ at_exit do
 end
 
 app = Rack::Builder.new do
-  map('/backend') { run BackendProxy.new }
+  # This has been replaced by ../backend-proxy/
+  # map('/backend') { run BackendProxy.new }
   map('/v0') { run App }
 end
 

--- a/backend-proxy/README.md
+++ b/backend-proxy/README.md
@@ -1,0 +1,31 @@
+# This directory contains a proxy server for cloudcmd
+
+For each user using Flight File Manager, the [API server](/api) launches a
+[cloudcmd process](/backend) process.  The process is provided with credentials
+that are created by the API server.  The credentials for cloudcmd are not the
+same credentials used to sign into Flight Web Suite.  [This
+server](/backend-proxy) is a reverse proxy to the cloudcmd process.  It
+examines the Flight Web Suite credentials, determines which cloudcmd process
+should be proxied to and determines the correct credentials for that process.
+Then it proxies the request.
+
+The original backend proxy was written in Ruby, used rack-proxy and ran under
+Puma.  Whilst it worked, it unfortunately had a memory leak.  It appears that
+the memory leak was in either Puma, or net/http.  Uploading or downloading
+large files would result in the File Manager API process consuming large
+amounts of memory and being killed by the OOM killer.
+
+Attempts to fix this in the Ruby reverse proxy were not successful, so a
+non-ruby solution has been implemented.
+
+The reverse proxy is very simple.  It needs to do the following:
+
+1. Check that the referer header is acceptable and abort if not.
+2. Obtain the credentials from the cloudcmd cookie.
+3. Map the username given in the cloudcmd cookie to a port.
+4. Proxy the request to that port, providing the credentials retrieved from the
+   cookie.
+5. Process each request in a constant amount of memory.
+
+Any server in any language that can do that would be suitable.  This one is
+written in Go.

--- a/backend-proxy/go.mod
+++ b/backend-proxy/go.mod
@@ -1,0 +1,3 @@
+module github.com/openflighthpc/flight-file-manager/backend-proxy
+
+go 1.22.1

--- a/backend-proxy/main.go
+++ b/backend-proxy/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+var (
+	addr               = flag.String("addr", "127.0.0.1:925", "address for this server to listen on")
+	cloudCmdCookieName = flag.String("cookie-name", "flight_file_manager_backend", "cookie name used for cloudcmd cookie")
+	dataDir            = flag.String("data-dir", "/opt/flight/var/lib/file-manager-api", "directory for runtime data about running cloudcmd servers")
+)
+
+func proxyHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := httputil.DumpRequest(r, false)
+	if err != nil {
+		log.Printf("Failed to dump http request: %s", err)
+	}
+
+	err = assertGoodOrigin(r)
+	if err != nil {
+		log.Printf("Invalid referrer: %s", err)
+		w.WriteHeader(403)
+		w.Write([]byte(fmt.Sprintf("Invalid referer: %s\n", err)))
+		return
+	}
+
+	username, password, err := credentialsFromCookies(r)
+	if err != nil {
+		log.Printf("Invalid credentials: %s", err)
+		w.WriteHeader(401)
+		w.Write([]byte("Invalid credentials\n"))
+		return
+	}
+	port, err := cloudCmdPort(username)
+	if err != nil {
+		log.Printf("%s", err)
+		w.WriteHeader(500)
+		w.Write([]byte(fmt.Sprintf("Unable to determine cloudcmd port: %s\n", err)))
+		return
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.Out.URL.Scheme = "http"
+			r.Out.URL.Host = fmt.Sprintf("127.0.0.1:%d", port)
+			r.Out.SetBasicAuth(username, password)
+			log.Printf("%s -> %s\n", r.In.URL.String(), r.Out.URL.String())
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func assertGoodOrigin(r *http.Request) error {
+	referrer := r.Referer()
+	// Work around Firefox sometimes not including the referer/origin header.
+	// But only for GET requests.
+	if referrer == "" {
+		if r.Method == "GET" {
+			return nil
+		}
+		return fmt.Errorf("referer not provided")
+	}
+
+	referrerUri, err := url.Parse(referrer)
+	if err != nil {
+		return fmt.Errorf("parsing referer header: %w", err)
+	}
+	if !strings.Contains(referrerUri.Hostname(), r.Host) && !strings.Contains(referrerUri.Host, r.Host) {
+		return fmt.Errorf("invalid referer: %s", r.Host)
+	}
+	return nil
+}
+
+func credentialsFromCookies(r *http.Request) (username string, password string, err error) {
+	cookie, err := r.Cookie(*cloudCmdCookieName)
+	if err != nil {
+		return "", "", err
+	}
+	// Ruby leaves a URL encoded linefeed at the end of the cookie value.
+	// Let's remove it.
+	cookieValue := strings.TrimRight(strings.TrimRight(cookie.Value, "%0A"), "%0a")
+	credentials, err := base64.StdEncoding.DecodeString(cookieValue)
+	if err != nil {
+		return "", "", err
+	}
+	parts := strings.Split(string(credentials), ":")
+	return parts[0], parts[1], nil
+}
+
+func cloudCmdPort(username string) (int, error) {
+	portPath := filepath.Join(*dataDir, username, "cloudcmd.port")
+	portString, err := os.ReadFile(portPath)
+	if err != nil {
+		return 0, fmt.Errorf("reading cloudcmd port for %s: %w", username, err)
+	}
+	port, err := strconv.Atoi(strings.TrimRight(string(portString), "\n"))
+	if err != nil {
+		return 0, fmt.Errorf("parsing cloudcmd port for %s: %w", username, err)
+	}
+	return port, nil
+}
+
+func main() {
+	flag.Parse()
+	http.HandleFunc("/", proxyHandler)
+	log.Printf("Starting proxy server on %s\n", *addr)
+	if err := http.ListenAndServe(*addr, nil); err != nil {
+		log.Fatal("ListenAndServe:", err)
+	}
+}


### PR DESCRIPTION
This PR fixes a memory leak for File manager backend proxying

For each user using Flight File Manager, the [API server](/api) launches a [cloudcmd process](/backend) process.  The process is provided with credentials that are created by the API server.  The credentials for cloudcmd are not the same credentials used to sign into Flight Web Suite.  [This server](/backend-proxy) is a reverse proxy to the cloudcmd process.  It examines the Flight Web Suite credentials, determines which cloudcmd process should be proxied to and determines the correct credentials for that process. Then it proxies the request.

The original backend proxy was written in Ruby, used rack-proxy and ran under Puma.  Whilst it worked, it unfortunately had a memory leak.  It appears that the memory leak was in either Puma, or net/http.  Uploading or downloading large files would result in the File Manager API process consuming large amounts of memory and being killed by the OOM killer.

Attempts to fix this in the Ruby reverse proxy were not successful, so a non-ruby solution has been implemented.

The reverse proxy is very simple.  It needs to do the following:

1. Check that the referer header is acceptable and abort if not.
2. Obtain the credentials from the cloudcmd cookie.
3. Map the username given in the cloudcmd cookie to a port.
4. Proxy the request to that port, providing the credentials retrieved from the cookie.
5. Process each request in a constant amount of memory.

Any server in any language that can do that would be suitable.  This one is written in Go.

Once built, the new reverse proxy server can be started with default configuration by running:

```bash
./backend-proxy
```

Non-default configuration is available via command-line arguments.  

```bash
[flight@gateway1 (mycluster1) [gateway1] ~]$ ./backend-proxy --help
Usage of ./backend-proxy:
  -addr string
    	address for this server to listen on (default "127.0.0.1:925")
  -cookie-name string
    	cookie name used for cloudcmd cookie (default "flight_file_manager_backend")
  -data-dir string
    	directory for runtime data about running cloudcmd servers (default "/opt/flight/var/lib/file-manager-api")
```

